### PR TITLE
Converting keywords to new sdcc form.

### DIFF
--- a/firmware/fx2/debug.c
+++ b/firmware/fx2/debug.c
@@ -3,7 +3,7 @@
 #include "debug.h"
 
 #ifdef DEBUG
-sbit at 0xB7 USART; // Port D7
+__sbit __at 0xB7 USART; // Port D7
 #define BAUD 32
 
 void usartInit(void) {
@@ -13,7 +13,7 @@ void usartInit(void) {
 
 void usartSendByte(uint8 c) {
 	(void)c; /* argument passed in DPL */
-	_asm
+	__asm
 		mov a, dpl
 		mov r1, #9
 		clr c
@@ -29,10 +29,10 @@ void usartSendByte(uint8 c) {
 		setb _USART
 		mov r0, #BAUD
 		djnz r0, .
-	_endasm;
+	__endasm;
 }
 void usartSendByteHex(uint8 byte) {
-	xdata uint8 ch;
+	__xdata uint8 ch;
 	ch = (byte >> 4) & 0x0F;
 	ch += (ch < 10 ) ? '0' : 'A' - 10;
 	usartSendByte(ch);
@@ -41,7 +41,7 @@ void usartSendByteHex(uint8 byte) {
 	usartSendByte(ch);
 }
 void usartSendWordHex(uint16 word) {
-	xdata uint8 ch;
+	__xdata uint8 ch;
 	ch = (word >> 12) & 0x0F;
 	ch += (ch < 10 ) ? '0' : 'A' - 10;
 	usartSendByte(ch);
@@ -56,7 +56,7 @@ void usartSendWordHex(uint16 word) {
 	usartSendByte(ch);
 }
 void usartSendLongHex(uint32 word) {
-	xdata uint8 ch;
+	__xdata uint8 ch;
 	ch = (word >> 28) & 0x0F;
 	ch += (ch < 10 ) ? '0' : 'A' - 10;
 	usartSendByte(ch);


### PR DESCRIPTION
Fixed some of the issues in https://github.com/makestuff/libfpgalink/issues/25

However now doesn't compile with;

```
$ make clean
rm -f *.iic *.asm *.hex *.lnk *.lst *.map *.mem *.rel *.rst *.sym *.lk firmware.c progOffsets.h date.inc
tansell@tansell-x1c-l:~/foss/makestuff/libs/libfpgalink/firmware/fx2$ make FLAGS="-DDEBUG"
echo DATE=0x20141222 > date.inc
echo VID=0x1D50 >> date.inc
echo PID=0x602B >> date.inc
echo DID=0x0002 >> date.inc
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common prog.c
cat prog.lst | ./lstParse.py > progOffsets.h
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common app.c
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common debug.c
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common infra.c
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common livePatch.c
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common prom.c
sdas8051 -logs descriptors.a51
cp ../../../../3rd/fx2lib/fw/fw.c firmware.c
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -c --disable-warning 85 -I sdcc -I../../../../3rd/fx2lib/include -I../../../../common firmware.c
sdcc -DDATE=0x20141222 -mmcs51 --code-size 0x1e00 --xram-loc 0xe000 --xram-size 0x0200 -Wl"-b DSCR_AREA=0x1e00" -Wl"-b INT2JT=0x1f00" -DDEBUG -o firmware.hex app.rel debug.rel infra.rel livePatch.rel prog.rel prom.rel descriptors.rel firmware.rel -L../../../../3rd/fx2lib/lib fx2.lib

?ASlink-Error-Insufficient ROM/EPROM/FLASH memory.
make: *** [firmware.hex] Error 1
```
