### PR TITLE
Fix DEBUG_FIRMWARE define in firmware.c copied from FX2LIB.

### DIFF
--- a/firmware/fx2/Makefile
+++ b/firmware/fx2/Makefile
@@ -83,7 +83,7 @@ date.inc:
 	echo DID=0x$(DID) >> $@
 
 firmware.c: $(FX2LIBDIR)/fw/fw.c
-	cp $(FX2LIBDIR)/fw/fw.c firmware.c
+	sed -e's/DEBUG_FIRMWARE/DEBUG/' $(FX2LIBDIR)/fw/fw.c > firmware.c
 
 clean: FORCE
 	rm -f *.iic *.asm *.hex *.lnk *.lst *.map *.mem *.rel *.rst *.sym *.lk firmware.c progOffsets.h date.inc


### PR DESCRIPTION
Fixes #27 

This is probably wrong though?
