### PR TITLE
Fixed lstParse.py per my proposal.

### DIFF
--- a/firmware/fx2/lstParse.py
+++ b/firmware/fx2/lstParse.py
@@ -25,16 +25,16 @@ tckList = []
 ioaList = []
 
 for line in fileinput.input():
-  m = re.search(r"^\s+([0-9A-F]+)\s+(A2|30) B0 (  |0C)\s+(\[\d+\]\s+)?\d+[^;]+_TDO.*?$", line)
+  m = re.search(r"^\s+([0-9A-F]+)\s+(72|82|A0|A2|10|20|30) B0 (  |[0-9A-F]+)\s+(\[\d+\]\s+)?\d+[^;]+_TDO.*?$", line)
   if ( m != None ):
     tdoList.append("0x{:04X}".format(1 + int(m.group(1), 16)))
-  m = re.search(r"^\s+([0-9A-F]+)\s+92 B1\s+(\[\d+\]\s+)?\d+[^;]+_TDI.*?$", line)
+  m = re.search(r"^\s+([0-9A-F]+)\s+[9BCD]2 B1\s+(\[\d+\]\s+)?\d+[^;]+_TDI.*?$", line)
   if ( m != None ):
     tdiList.append("0x{:04X}".format(1 + int(m.group(1), 16)))
-  m = re.search(r"^\s+([0-9A-F]+)\s+[9D]2 B2\s+(\[\d+\]\s+)?\d+[^;]+_TMS.*?$", line)
+  m = re.search(r"^\s+([0-9A-F]+)\s+[9BCD]2 B2\s+(\[\d+\]\s+)?\d+[^;]+_TMS.*?$", line)
   if ( m != None ):
     tmsList.append("0x{:04X}".format(1 + int(m.group(1), 16)))
-  m = re.search(r"^\s+([0-9A-F]+)\s+[CD]2 B3\s+(\[\d+\]\s+)?\d+[^;]+_TCK.*?$", line)
+  m = re.search(r"^\s+([0-9A-F]+)\s+[9BCD]2 B3\s+(\[\d+\]\s+)?\d+[^;]+_TCK.*?$", line)
   if ( m != None ):
     tckList.append("0x{:04X}".format(1 + int(m.group(1), 16)))
   m = re.search(r"^\s+([0-9A-F]+)\s+85 9C 80", line)


### PR DESCRIPTION
OK, I looked at this page for a 8051 instruction reference: 8051 Instruction Set Manual: Opcodes (keil.com)
I searched for every instructions dealing with bits. Some take bit as input, some as destination. 
The ones used for input can  be used with TDO the other ones can be used with TDI, TMS, TCK. 
All instructions are 2 bytes except for the  jumps that take an offset, which can be any byte value. 
This leads to the following regexps:
m = re.search(r"^\s+([0-9A-F]+)\s+(72|82|A0|A2|10|20|30) B0 (  |[0-9A-F]+)\s+(\[\d+\]\s+)?\d+[^;]+_TDO.*?$", line)
m = re.search(r"^\s+([0-9A-F]+)\s+[9BCD]2 B1\s+(\[\d+\]\s+)?\d+[^;]+_TDI.*?$", line)
m = re.search(r"^\s+([0-9A-F]+)\s+[9BCD]2 B2\s+(\[\d+\]\s+)?\d+[^;]+_TMS.*?$", line)
m = re.search(r"^\s+([0-9A-F]+)\s+[9BCD]2 B3\s+(\[\d+\]\s+)?\d+[^;]+_TCK.*?$", line)

I think these expression will make the decoder much more resilient to program changes. In particular, the jump offset was assumed to be a constant 0B but It changes to 0C with the version of SDCC that we are using now. 
This leaves _IOA very fragile but this is a special case anyway. 
What do you think? 