### PR TITLE
cmake: adapt library install dir according to the host OS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 project(fpgalink)
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(LIBFPGALINK_LIB_DIR "bin")
+else()
+  set(LIBFPGALINK_LIB_DIR "lib")
+endif()
+
 # Create a shared library
 file(GLOB SOURCES src/*.cpp src/*.c)
 add_library(${PROJECT_NAME} SHARED ${SOURCES})
@@ -14,11 +20,30 @@ target_link_libraries(${PROJECT_NAME} PUBLIC ${LIB_DEPENDS})
 # What to install
 install(TARGETS ${PROJECT_NAME}
   RUNTIME DESTINATION bin
-  LIBRARY DESTINATION bin
-  ARCHIVE DESTINATION bin
+  LIBRARY DESTINATION ${LIBFPGALINK_LIB_DIR}
+  ARCHIVE DESTINATION ${LIBFPGALINK_LIB_DIR}
 )
 install(
   DIRECTORY include/makestuff DESTINATION include
+)
+
+########################################################################
+# Create Pkg Config File
+########################################################################
+file(TO_NATIVE_PATH "${CMAKE_INSTALL_PREFIX}"                prefix)
+file(TO_NATIVE_PATH "\${prefix}"                             exec_prefix)
+file(TO_NATIVE_PATH "\${exec_prefix}/${LIBFPGALINK_LIB_DIR}" libdir)
+file(TO_NATIVE_PATH "\${prefix}/include"                     includedir)
+
+
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/libfpgalink.pc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/libfpgalink.pc
+@ONLY)
+
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/libfpgalink.pc
+  DESTINATION ${LIBFPGALINK_LIB_DIR}/pkgconfig
 )
 
 # Maybe build tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,8 @@ project(fpgalink)
 if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(LIBFPGALINK_LIB_DIR "bin")
 else()
-  set(LIBFPGALINK_LIB_DIR "lib")
+  include(GNUInstallDirs)
+  set(LIBFPGALINK_LIB_DIR ${CMAKE_INSTALL_LIBDIR})
 endif()
 
 # Create a shared library


### PR DESCRIPTION
By default, and for a windows target, libraries are usually installed in bin directory. But for linux target OS the usual place is lib.
This PR add an cmake variable pointing to bin or lib according to the host system, and used in the install rule.
